### PR TITLE
Increase default JSON body limit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -37,12 +37,18 @@ At the moment, the supported LLMs by GitHub Copilot are: "gpt-4o", "gpt-4o-mini"
 
 The extension provides a configuration setting to specify the port for the Express server:
 
-- **Setting:** `copilotProxy.port`  
+- **Setting:** `copilotProxy.port`
   **Default:** `3000`
 
 You can change this setting in two ways:
 - **Via Settings UI:** Open the VS Code Settings (`Ctrl+,` or `Cmd+,`) and search for "Copilot Proxy".
 - **Via Command Palette:** Run the command **"Copilot Proxy: Configure Port"** to interactively set the port.
+
+### Adjusting Request Size Limit
+
+The proxy limits JSON request bodies to 5&nbsp;MB by default. If you encounter
+`PayloadTooLargeError`, set the environment variable `JSON_LIMIT` to a higher
+value (e.g., `10mb`) before starting the server.
 
 ## Using the Extension
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,8 +9,9 @@ dotenv.config();
 
 const app = express();
 
-// Middleware to parse JSON bodies
-app.use(express.json());
+// Middleware to parse JSON bodies with configurable limit
+const jsonLimit = process.env.JSON_LIMIT || '5mb';
+app.use(express.json({ limit: jsonLimit }));
 
 // Logger middleware
 app.use(morgan('combined'));


### PR DESCRIPTION
## Summary
- allow configuring JSON request size via `JSON_LIMIT`
- document the new environment variable in the README

## Testing
- `npm run build` *(fails: Cannot find type definition file for 'body-parser')*

------
https://chatgpt.com/codex/tasks/task_e_683ff93af01c832a9daf67202ec119cc